### PR TITLE
Trailing commas can be removed form Array too

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function removeTrailingComma(source) {
   var collectedDatas = []
 
   syntax.tokens.forEach(function(token, index, tokens) {
-    if (token.type === "Punctuator" && token.value === "}" && tokens[index - 1].type === "Punctuator" && tokens[index - 1].value === ",") {
+    if (token.type === "Punctuator" && ( token.value === "}" || token.value === "]" ) && tokens[index - 1].type === "Punctuator" && tokens[index - 1].value === ",") {
       collectedDatas.push({
         range: tokens[index - 1].range,
         replaceString: ""


### PR DESCRIPTION
I found this module very useful but I noticed it could not remove trailing commas from Arrays. With this edit support for trailing commas in Array is added. Hope is useful to anyone.
